### PR TITLE
David editing maps

### DIFF
--- a/maps/map1.txt
+++ b/maps/map1.txt
@@ -1,5 +1,5 @@
 xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-x   x           x       x              x
+x     cccccccc                         x
 x                       x              x
 x                       x              x
 x                       x              x

--- a/maps/map4.txt
+++ b/maps/map4.txt
@@ -1,0 +1,24 @@
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+x                                    qx
+x          x                          x
+x   f   x                             x
+x  x             f                    x
+x                                     x
+x           x                         x
+x   x     x                           x
+x         fxxffxxff xxxxxxxxxxxxxxxxxxx
+x     xxg          fx                 x
+x       x  x        x                 x
+x                ff x                 x
+x         x   xxxx  x                 x
+x                   x                 x
+x              f    x                 x
+x            f    x    x              x
+x      xxxx           x               x
+x             f  f     fffffff       px
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+[p] map5.txt
+[q] map6.txt
+
+

--- a/src/player.rs
+++ b/src/player.rs
@@ -12,6 +12,8 @@ pub struct Player {
 	sprite_bg1: Texture2D,
 	pub can_portal: bool,
 	pub coins: i32,
+        pub spawn_x: i32,
+        pub spawn_y: i32,
 }
 
 impl Player {
@@ -21,9 +23,18 @@ impl Player {
 
 		let sprite_bg1 = load_texture("sprites/bg1.png").await.unwrap();
 		sprite_bg1.set_filter(FilterMode::Nearest);
-
+                for solid in ['P', 'Q', 'S'].iter(){
+                    match map.get_solid(self.center_x(), self.center_y(), *solid){
+                        some((x, y, _tile_x, _tile_y) => {
+                            self.spawn_x = x;
+                            self.spawn_y = y;
+                        },
+                        None => { 
+                        }
+                    }
+                }
 		Player {
-			x: Map::TILE_SIZE, y: Map::TILE_SIZE, vx: 0.0, vy: 0.0, g: 0.1, sprite_bg1: sprite_bg1, can_portal: false, coins: 0,
+			x: self.spawn_x, y: self_spawn_y, vx: 0.0, vy: 0.0, g: 0.1, sprite_bg1: sprite_bg1, can_portal: false, coins: 0,
 		}
 	}
 
@@ -339,7 +350,7 @@ impl Player {
 				}
 			}
 			if distance == 0.0 {
-				self.vy = -4.1;
+				self.vy = -4.1*0.65;
 			}
 		}
 	}


### PR DESCRIPTION
The character now (should) spawn at a Q,S or P block instead of just top left corner. It should be noted that i haven´t made it so that you can choose which of these three blocks the character spawns at (will fix). Note that i have not coded anything after "None =>" meaning that an error will occur if no Q, S or P blocks are found. The maps are also not updated meaning the game will not work until you add one of these blocks into your maps. (i will fix all of these issues).